### PR TITLE
Do not forcefully enable metrics collection

### DIFF
--- a/src/one/lindegaard/MobHunting/MetricsManager.java
+++ b/src/one/lindegaard/MobHunting/MetricsManager.java
@@ -299,22 +299,6 @@ public class MetricsManager {
 		metrics.addGraph(usageGraph);
 		metrics.start();
 		Messages.debug("Metrics started");
-		Bukkit.getScheduler().runTaskTimer(MobHunting.getInstance(), new Runnable() {
-			public void run() {
-				try {
-					if (isMCStatsReachable()) {
-						metrics.enable();
-					} else {
-						metrics.disable();
-						Messages.debug("Http://mcstats.org seems to be down");
-					}
-				} catch (IOException e) {
-					e.printStackTrace();
-				}
-
-			}
-		}, 100, 36000);
-		
 	}
 
 	public static boolean isMCStatsReachable() {


### PR DESCRIPTION
this is bad. you completely demolish the privacy of server owners. if someone chooses to opt-out, then that is his choice and you should respect that. what you are doing now is to trample upon their freedom. 
