### PR TITLE
Fix SSL warning for MYSQL

### DIFF
--- a/src/one/lindegaard/MobHunting/config/ConfigManager.java
+++ b/src/one/lindegaard/MobHunting/config/ConfigManager.java
@@ -4349,6 +4349,9 @@ public class ConfigManager extends AutoConfig {
 	@ConfigField(name = "host", category = "database.mysql")
 	public String databaseHost = "localhost:3306";
 
+  @ConfigField(name = "useSSL", category = "database.mysql")
+  public String databaseUseSSL = "false";
+
 	@ConfigField(name = "database_version", category = "database", comment = "This is the database layout version. Mostly for internal use and you should not need"
 			+ "\nto chance this value. In case you decide to delete your database and let it recreate"
 			+ "\nor if you chance database type sqlite/mysql you should set this value to 0 again.")

--- a/src/one/lindegaard/MobHunting/storage/MySQLDataStore.java
+++ b/src/one/lindegaard/MobHunting/storage/MySQLDataStore.java
@@ -52,7 +52,8 @@ public class MySQLDataStore extends DatabaseDataStore {
 			} else {
 				dataSource.setServerName(plugin.getConfigManager().databaseHost);
 			}
-			dataSource.setDatabaseName(plugin.getConfigManager().databaseName + "?autoReconnect=true");
+			dataSource.setDatabaseName(plugin.getConfigManager().databaseName
+          + "?autoReconnect=true&useSSL="+plugin.getConfigManager().databaseUseSSL);
 			Connection c = dataSource.getConnection();
 			Statement statement = c.createStatement();
 			statement.executeUpdate("SET NAMES 'utf8'");


### PR DESCRIPTION
Add a simple fix for the mysql SSL warnings...this allows a server owner to explicity define ssl settings

Signed-off-by: Narimm <benjicharlton@gmail.com>