### PR TITLE
MobHunting JL - Shutdown Stability and 1.21.11 Compatibility Hardening

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>MobHunting</artifactId>
 	<packaging>jar</packaging>
 	<!-- <version>8.5.5</version>  -->
-	<version>8.5.7-rc2</version>
+	<version>8.5.7-rc2-JL.1</version>
 	<!-- <version>8.1.9-SNAPSHOT-B${build.number}</version> -->
 	<name>MobHunting</name>
 	<url>https://www.spigotmc.org/resources/mobhunting.3582/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>MobHunting</artifactId>
 	<packaging>jar</packaging>
 	<!-- <version>8.5.5</version>  -->
-	<version>8.5.7-rc2-JL.1</version>
+	<version>8.5.7-rc2-JL.2</version>
 	<!-- <version>8.1.9-SNAPSHOT-B${build.number}</version> -->
 	<name>MobHunting</name>
 	<url>https://www.spigotmc.org/resources/mobhunting.3582/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>MobHunting</artifactId>
 	<packaging>jar</packaging>
 	<!-- <version>8.5.5</version>  -->
-	<version>8.5.6-SNAPSHOT</version>
+	<version>8.5.6</version>
 	<!-- <version>8.1.9-SNAPSHOT-B${build.number}</version> -->
 	<name>MobHunting</name>
 	<url>https://www.spigotmc.org/resources/mobhunting.3582/</url>
@@ -18,7 +18,8 @@
 	</parent>
 
 	<properties>
-		<bagofgold.version>4.5.6-SNAPSHOT</bagofgold.version>
+		<customitemslib.version>1.1.0</customitemslib.version>
+		<bagofgold.version>4.5.6</bagofgold.version>
 
 		<minigameslib.version>1.14.16</minigameslib.version>
 		<minigames.version>	1.11.0</minigames.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>MobHunting</artifactId>
 	<packaging>jar</packaging>
 	<!-- <version>8.5.5</version>  -->
-	<version>8.5.6</version>
+	<version>8.5.7-rc2</version>
 	<!-- <version>8.1.9-SNAPSHOT-B${build.number}</version> -->
 	<name>MobHunting</name>
 	<url>https://www.spigotmc.org/resources/mobhunting.3582/</url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<artifactId>MobHunting</artifactId>
 	<packaging>jar</packaging>
 	<!-- <version>8.5.5</version>  -->
-	<version>8.5.7-rc2-JL.2</version>
+	<version>8.5.7-rc2-JL.3</version>
 	<!-- <version>8.1.9-SNAPSHOT-B${build.number}</version> -->
 	<name>MobHunting</name>
 	<url>https://www.spigotmc.org/resources/mobhunting.3582/</url>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ dev-url: https://dev.bukkit.org/projects/mobhunting
 author: Rocologo
 depend: [CustomItemsLib]
 softdepend: [Vault, Reserve, Multiverse-Core, Essentials, BagOfGold, WorldEdit, WorldGuard, PreciousStones, HolographicDisplays, Holograms, CMI, CMILib, Factions, Towny, Residence, ProtocolLib, mcMMO, BossShop, MythicMobs, TARDISWeepingAngels, InfernalMobs, Boss, Citizens, Sentry, Sentinel, Minigames, MinigamesLib, MyPet, MobArena, PVPArena, BattleArena, LibsDisguises, DisguiseCraft, iDisguise, VanishNoPacket, BossBarAPI, BarAPI, ActionBar, TitleAPI, TitleManager, PlaceholderAPI, MobStacker, Gringotts, ActionBarAPI, ActionAnnouncer, CustomMobs, ConquestiaMobs, LevelledMobs, StackMob, MysteriousHalloween, SmartGiants, ExtraHardMode, CrackShot, WeaponMechanics]
-api-version: 1.13
+api-version: 1.21
 
 commands:
   mobhunt:

--- a/src/one/lindegaard/MobHunting/achievements/AchievementManager.java
+++ b/src/one/lindegaard/MobHunting/achievements/AchievementManager.java
@@ -401,9 +401,9 @@ public class AchievementManager implements Listener {
 				return;
 			}
 
-		// TODO: maybe Advancements API does not work on Paper?
+		// Guard against servers where advancement manager is intentionally unavailable.
 		if (Servers.isSpigotServer() && !plugin.getConfigManager().disableMobHuntingAdvancements
-				&& Servers.isMC112OrNewer())
+				&& Servers.isMC112OrNewer() && plugin.getAdvancementManager() != null)
 			plugin.getAdvancementManager().grantAdvancement(player, achievement);
 
 		PlayerStorage storage = mStorage.get(player.getUniqueId());
@@ -661,7 +661,7 @@ public class AchievementManager implements Listener {
 
 						// Advancements is not supported on older servers and on PaperSpigot.
 						if (!plugin.getConfigManager().disableMobHuntingAdvancements && Servers.isMC113OrNewer()
-								&& !Servers.isPaperServer())
+								&& !Servers.isPaperServer() && plugin.getAdvancementManager() != null)
 							plugin.getAdvancementManager().updatePlayerAdvancements(player);
 
 					}

--- a/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
+++ b/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
@@ -44,6 +44,7 @@ public class CitizensCompat implements Listener {
 	private static YamlConfiguration config = new YamlConfiguration();
 	public static final String MH_CITIZENS = "MH:CITIZENS";
 	private static boolean traitLookupWarningLogged = false;
+	private static boolean traitClassMissingLogged = false;
 
 	public CitizensCompat() {
 		if (!isEnabledInConfig()) {
@@ -250,6 +251,15 @@ public class CitizensCompat implements Listener {
 	}
 
 	private static void logTraitLookupIssue(String reason, String traitName, Throwable t) {
+		if ("Trait class not found".equals(reason)) {
+			if (traitClassMissingLogged)
+				return;
+			traitClassMissingLogged = true;
+			MobHunting.getInstance().getMessages().debug(
+					"Citizens trait '%s' not present. Skipping optional Sentry/Sentinel checks.", traitName);
+			return;
+		}
+
 		if (traitLookupWarningLogged)
 			return;
 		traitLookupWarningLogged = true;

--- a/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
+++ b/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
@@ -141,9 +141,28 @@ public class CitizensCompat implements Listener {
 	// OTHER FUNCTIONS
 	// **************************************************************************
 	public static void shutdown() {
-		if (supported) {
-			TraitInfo trait = TraitInfo.create(MasterMobHunterTrait.class).withName("MasterMobHunter");
-			citizensAPI.getTraitFactory().deregisterTrait(trait);
+		if (!supported || citizensAPI == null) {
+			return;
+		}
+
+		TraitInfo trait = TraitInfo.create(MasterMobHunterTrait.class).withName("MasterMobHunter");
+		try {
+			Object traitFactory = citizensAPI.getTraitFactory();
+			if (traitFactory == null) {
+				return;
+			}
+
+			try {
+				traitFactory.getClass().getMethod("deregisterTrait", TraitInfo.class).invoke(traitFactory, trait);
+			} catch (NoSuchMethodException ignored) {
+				MobHunting.getInstance().getMessages()
+						.debug("Citizens TraitFactory has no deregisterTrait(TraitInfo); skipping trait deregistration.");
+			}
+		} catch (Throwable t) {
+			Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+					+ "Failed to deregister MasterMobHunter trait during Citizens shutdown cleanup.");
+			MobHunting.getInstance().getMessages().debug("Citizens shutdown cleanup error: %s: %s",
+					t.getClass().getSimpleName(), t.getMessage());
 		}
 	}
 

--- a/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
+++ b/src/one/lindegaard/MobHunting/compatibility/CitizensCompat.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.lang.reflect.InvocationTargetException;
 
 import net.citizensnpcs.api.CitizensAPI;
 import net.citizensnpcs.api.CitizensPlugin;
@@ -42,6 +43,7 @@ public class CitizensCompat implements Listener {
 	private static File fileMobRewardData = new File(MobHunting.getInstance().getDataFolder(), "citizens-rewards.yml");
 	private static YamlConfiguration config = new YamlConfiguration();
 	public static final String MH_CITIZENS = "MH:CITIZENS";
+	private static boolean traitLookupWarningLogged = false;
 
 	public CitizensCompat() {
 		if (!isEnabledInConfig()) {
@@ -205,26 +207,59 @@ public class CitizensCompat implements Listener {
 	}
 
 	public static boolean isSentryOrSentinelOrSentries(Entity entity) {
-		if (isNPC(entity))
-			return CitizensAPI.getNPCRegistry().getNPC(entity)
-					.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentry"))
-					|| CitizensAPI.getNPCRegistry().getNPC(entity)
-							.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentinel"))
-					|| CitizensAPI.getNPCRegistry().getNPC(entity)
-							.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentries"));
-		return false;
+		if (entity == null || !isNPC(entity))
+			return false;
+		return isSentryOrSentinelOrSentries(CitizensAPI.getNPCRegistry().getNPC(entity));
 	}
 
 	public static boolean isSentryOrSentinelOrSentries(String mobtype) {
-		if (CitizensCompat.isNPC(Integer.valueOf(mobtype)))
-			return CitizensAPI.getNPCRegistry().getById(Integer.valueOf(mobtype))
-					.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentry"))
-					|| CitizensAPI.getNPCRegistry().getById(Integer.valueOf(mobtype))
-							.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentinel"))
-					|| CitizensAPI.getNPCRegistry().getById(Integer.valueOf(mobtype))
-							.hasTrait(CitizensAPI.getTraitFactory().getTraitClass("Sentries"));
-		else
+		if (!CitizensCompat.isNPC(Integer.valueOf(mobtype)))
 			return false;
+		return isSentryOrSentinelOrSentries(CitizensAPI.getNPCRegistry().getById(Integer.valueOf(mobtype)));
+	}
+
+	private static boolean isSentryOrSentinelOrSentries(NPC npc) {
+		if (npc == null)
+			return false;
+		return hasTraitSafely(npc, "Sentry") || hasTraitSafely(npc, "Sentinel") || hasTraitSafely(npc, "Sentries");
+	}
+
+	private static boolean hasTraitSafely(NPC npc, String traitName) {
+		if (npc == null || traitName == null)
+			return false;
+		try {
+			Class<?> traitClass = CitizensAPI.getTraitFactory().getTraitClass(traitName);
+			if (traitClass == null) {
+				logTraitLookupIssue("Trait class not found", traitName, null);
+				return false;
+			}
+
+			// Prefer reflection so we can short-circuit null/invalid class values across Citizens versions.
+			Object result = npc.getClass().getMethod("hasTrait", Class.class).invoke(npc, traitClass);
+			return result instanceof Boolean && (Boolean) result;
+		} catch (NoSuchMethodException e) {
+			logTraitLookupIssue("NPC.hasTrait(Class) missing", traitName, e);
+		} catch (IllegalAccessException e) {
+			logTraitLookupIssue("NPC.hasTrait(Class) access denied", traitName, e);
+		} catch (InvocationTargetException e) {
+			logTraitLookupIssue("NPC.hasTrait(Class) threw", traitName, e.getCause() != null ? e.getCause() : e);
+		} catch (Throwable t) {
+			logTraitLookupIssue("Unexpected Citizens trait lookup error", traitName, t);
+		}
+		return false;
+	}
+
+	private static void logTraitLookupIssue(String reason, String traitName, Throwable t) {
+		if (traitLookupWarningLogged)
+			return;
+		traitLookupWarningLogged = true;
+		Bukkit.getConsoleSender().sendMessage(
+				MobHunting.PREFIX_WARNING + "Citizens trait lookup degraded (" + reason + ") for '" + traitName
+						+ "'. Sentinel/Sentry checks are skipped safely.");
+		if (t != null) {
+			MobHunting.getInstance().getMessages().debug("Citizens trait lookup details: %s: %s",
+					t.getClass().getSimpleName(), t.getMessage());
+		}
 	}
 
 	public static HashMap<String, ExtendedMobRewardData> getMobRewardData() {
@@ -270,7 +305,8 @@ public class CitizensCompat implements Listener {
 		NPCRegistry n = CitizensAPI.getNPCRegistry();
 		for (Iterator<NPC> npcList = n.iterator(); npcList.hasNext();) {
 			NPC npc = npcList.next();
-			if (isSentryOrSentinelOrSentries(npc.getEntity())) {
+			Entity entity = npc.getEntity();
+			if (entity != null && isSentryOrSentinelOrSentries(entity)) {
 				if (mMobRewardData != null && !mMobRewardData.containsKey(String.valueOf(npc.getId()))) {
 					MobHunting.getInstance().getMessages().debug("A new Sentinel or Sentry NPC was found. ID=%s,%s",
 							npc.getId(), npc.getName());
@@ -280,7 +316,7 @@ public class CitizensCompat implements Listener {
 					saveCitizensData(String.valueOf(npc.getId()));
 				}
 			}
-			if (CitizensCompat.getMasterMobHunterManager().isMasterMobHunter(npc.getEntity())) {
+			if (entity != null && CitizensCompat.getMasterMobHunterManager().isMasterMobHunter(entity)) {
 				if (!CitizensCompat.getMasterMobHunterManager().contains(npc.getId())) {
 					MasterMobHunter masterMobHunter = new MasterMobHunter(MobHunting.getInstance(), npc);
 					CitizensCompat.getMasterMobHunterManager().put(npc.getId(), masterMobHunter);
@@ -288,7 +324,7 @@ public class CitizensCompat implements Listener {
 							npc.getFullName(), true, "0", 1, "You killed a Citizen",
 							new ArrayList<HashMap<String, String>>(), 1, 0.02);
 					CitizensCompat.getMobRewardData().put(String.valueOf(npc.getId()), rewardData);
-					npc.getEntity().setMetadata(CitizensCompat.MH_CITIZENS,
+					entity.setMetadata(CitizensCompat.MH_CITIZENS,
 							new FixedMetadataValue(MobHunting.getInstance(), rewardData));
 					MobHunting.getInstance().getStoreManager().insertCitizensMobs(String.valueOf(npc.getId()));
 					counter++;

--- a/src/one/lindegaard/MobHunting/compatibility/TownyCompat.java
+++ b/src/one/lindegaard/MobHunting/compatibility/TownyCompat.java
@@ -15,24 +15,35 @@ public class TownyCompat {
 	// http://towny.palmergames.com/
 
 	public TownyCompat() {
+		supported = false;
 		if (!isEnabledInConfig()) {
 			Bukkit.getConsoleSender()
 					.sendMessage(MobHunting.PREFIX_WARNING + "Compatibility with Towny is disabled in config.yml");
-		} else {
-			mPlugin = Bukkit.getPluginManager().getPlugin(CompatPlugin.Towny.getName());
+			return;
+		}
 
-			try {
-				@SuppressWarnings({ "rawtypes", "unused" })
-				Class cls = Class.forName("com.palmergames.bukkit.towny.object.TownyUniverse");
-				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX + "Enabling compatibility with Towny ("
-						+ mPlugin.getDescription().getVersion() + ").");
+		mPlugin = Bukkit.getPluginManager().getPlugin(CompatPlugin.Towny.getName());
+		if (mPlugin == null) {
+			Bukkit.getConsoleSender()
+					.sendMessage(MobHunting.PREFIX_WARNING + "Towny plugin not found. Compatibility is disabled.");
+			return;
+		}
+
+		try {
+			Class.forName("com.palmergames.bukkit.towny.TownyAPI");
+			if (TownyHelper.initializeBridge()) {
+				Bukkit.getConsoleSender().sendMessage(
+						MobHunting.PREFIX + "Enabling compatibility with Towny (" + mPlugin.getDescription().getVersion() + ")");
 				supported = true;
-			} catch (ClassNotFoundException e) {
-				Bukkit.getConsoleSender()
-						.sendMessage(MobHunting.PREFIX_WARNING + "Your version of Towny ("
-								+ mPlugin.getDescription().getVersion()
-								+ ") is not complatible with this version of MobHunting, please upgrade.");
+			} else {
+				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING + "Your version of Towny ("
+						+ mPlugin.getDescription().getVersion()
+						+ ") is not compatible with this MobHunting Towny integration (Towny 0.102+ API expected).");
 			}
+		} catch (ClassNotFoundException e) {
+			Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING + "Your version of Towny ("
+					+ mPlugin.getDescription().getVersion()
+					+ ") is not compatible with this MobHunting Towny integration (Towny 0.102+ API expected).");
 		}
 	}
 

--- a/src/one/lindegaard/MobHunting/compatibility/TownyHelper.java
+++ b/src/one/lindegaard/MobHunting/compatibility/TownyHelper.java
@@ -1,87 +1,198 @@
 package one.lindegaard.MobHunting.compatibility;
 
-import java.util.List;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
 import org.bukkit.entity.Player;
-
-import com.palmergames.bukkit.towny.exceptions.NotRegisteredException;
-import com.palmergames.bukkit.towny.object.Resident;
-import com.palmergames.bukkit.towny.object.Town;
-import com.palmergames.bukkit.towny.object.TownBlock;
-import com.palmergames.bukkit.towny.object.TownyPermission;
-import com.palmergames.bukkit.towny.object.TownyUniverse;
 
 import one.lindegaard.MobHunting.MobHunting;
 
 public class TownyHelper {
 
-	public static boolean isInHomeTown(Player player) {
-		if (TownyCompat.isSupported()) {
-			Resident resident;
-			Town homeTown = null;
-			try {
-				resident = TownyUniverse.getDataSource().getResident(player.getName());
-			} catch (NotRegisteredException ex) {
-				// MobHunting.getInstance().getMessages().debug("Could not find the Resident (%s)",
-				// player.getName());
-				return false;
-			}
+	private static boolean initialized = false;
+	private static boolean bridgeReady = false;
+	private static boolean runtimeWarningLogged = false;
 
-			if (resident != null) {
-				try {
-					homeTown = resident.getTown();
-				} catch (NotRegisteredException e) {
-					// MobHunting.getInstance().getMessages().debug("%s has no town", player.getName());
-					return false;
-				}
-			}
+	private static Method townyApiGetInstanceMethod;
+	private static Method townyApiGetResidentMethod;
+	private static Method townyApiGetTownBlockMethod;
+	private static Method residentGetTownMethod;
+	private static Method residentGetTownOrNullMethod;
+	private static Method townBlockGetTownMethod;
+	private static Method townBlockGetTownOrNullMethod;
 
-			TownBlock tb = TownyUniverse.getTownBlock(player.getLocation());
-			if (tb != null) {
-				// Location is within a town
-				try {
-					MobHunting.getInstance().getMessages().debug("%s is in a town (%s)", player.getName(), tb.getTown().getName());
-				} catch (NotRegisteredException e) {
-				}
-			} else {
-				// MobHunting.getInstance().getMessages().debug("The player is not in a town");
-				return false;
-			}
-
-			try {
-				// Check if the town is the residents town.
-				List<Resident> residents = tb.getTown().getResidents();
-				if (residents.contains(resident) || tb.getTown().equals(homeTown)) {
-					// check if town is protected against mob damage
-					TownyPermission p1 = homeTown.getPermissions();
-					Boolean protected_mob = p1.mobs;
-					MobHunting.getInstance().getMessages().debug("%s is in his HomeTown. Mob spawns:%s", player.getName(),
-							protected_mob ? "On" : "Off");
-					return true;
-				} else {
-					// MobHunting.getInstance().getMessages().debug("%s is not in his home town",
-					// player.getName());
-					return false;
-				}
-			} catch (NotRegisteredException e) {
-				return false;
-			}
+	public static synchronized boolean initializeBridge() {
+		if (initialized) {
+			return bridgeReady;
 		}
-		return false;
+
+		initialized = true;
+		bridgeReady = false;
+
+		try {
+			Class<?> townyApiClass = Class.forName("com.palmergames.bukkit.towny.TownyAPI");
+			Class<?> residentClass = Class.forName("com.palmergames.bukkit.towny.object.Resident");
+			Class<?> townBlockClass = Class.forName("com.palmergames.bukkit.towny.object.TownBlock");
+
+			townyApiGetInstanceMethod = townyApiClass.getMethod("getInstance");
+			townyApiGetResidentMethod = townyApiClass.getMethod("getResident", Player.class);
+			townyApiGetTownBlockMethod = townyApiClass.getMethod("getTownBlock", Location.class);
+
+			residentGetTownOrNullMethod = findMethod(residentClass, "getTownOrNull");
+			residentGetTownMethod = findMethod(residentClass, "getTown");
+			townBlockGetTownOrNullMethod = findMethod(townBlockClass, "getTownOrNull");
+			townBlockGetTownMethod = findMethod(townBlockClass, "getTown");
+
+			if ((residentGetTownOrNullMethod == null && residentGetTownMethod == null)
+					|| (townBlockGetTownOrNullMethod == null && townBlockGetTownMethod == null)) {
+				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+						+ "Towny compatibility disabled: unsupported Towny API (missing town resolver methods). ");
+				return false;
+			}
+
+			Object townyApi = townyApiGetInstanceMethod.invoke(null);
+			if (townyApi == null) {
+				Bukkit.getConsoleSender().sendMessage(
+						MobHunting.PREFIX_WARNING + "Towny compatibility disabled: TownyAPI.getInstance() returned null.");
+				return false;
+			}
+
+			bridgeReady = true;
+			return true;
+		} catch (Throwable t) {
+			Bukkit.getConsoleSender()
+					.sendMessage(MobHunting.PREFIX_WARNING + "Towny compatibility disabled: " + shortError(t));
+			return false;
+		}
+	}
+
+	public static boolean isInHomeTown(Player player) {
+		if (!TownyCompat.isSupported() || player == null || !initializeBridge()) {
+			return false;
+		}
+
+		try {
+			Object townyApi = townyApiGetInstanceMethod.invoke(null);
+			if (townyApi == null) {
+				warnRuntime("TownyAPI.getInstance() returned null.", null);
+				return false;
+			}
+
+			Object resident = townyApiGetResidentMethod.invoke(townyApi, player);
+			if (resident == null) {
+				MobHunting.getInstance().getMessages().debug("%s is not a Towny resident", player.getName());
+				return false;
+			}
+
+			Object townBlock = townyApiGetTownBlockMethod.invoke(townyApi, player.getLocation());
+			if (townBlock == null) {
+				return false;
+			}
+
+			Object residentTown = resolveResidentTown(resident);
+			Object townBlockTown = resolveTownBlockTown(townBlock);
+			if (residentTown == null || townBlockTown == null) {
+				return false;
+			}
+
+			boolean inHomeTown = residentTown.equals(townBlockTown);
+			if (inHomeTown) {
+				MobHunting.getInstance().getMessages().debug("%s is in his HomeTown", player.getName());
+			}
+			return inHomeTown;
+		} catch (InvocationTargetException e) {
+			warnRuntime("resolving Towny home-town check", e.getTargetException());
+			return false;
+		} catch (Throwable t) {
+			warnRuntime("resolving Towny home-town check", t);
+			return false;
+		}
 	}
 
 	public static boolean isInAnyTomn(Player player) {
-		if (TownyCompat.isSupported()) {
-			TownBlock tb = TownyUniverse.getTownBlock(player.getLocation());
-			if (tb != null) {
-				// Location is within a town
-				return true;
-			} else {
-				// MobHunting.getInstance().getMessages().debug("The player is not in a town");
+		if (!TownyCompat.isSupported() || player == null || !initializeBridge()) {
+			return false;
+		}
+
+		try {
+			Object townyApi = townyApiGetInstanceMethod.invoke(null);
+			if (townyApi == null) {
+				warnRuntime("TownyAPI.getInstance() returned null.", null);
 				return false;
 			}
+
+			Object townBlock = townyApiGetTownBlockMethod.invoke(townyApi, player.getLocation());
+			return townBlock != null;
+		} catch (InvocationTargetException e) {
+			warnRuntime("resolving Towny any-town check", e.getTargetException());
+			return false;
+		} catch (Throwable t) {
+			warnRuntime("resolving Towny any-town check", t);
+			return false;
 		}
-		return false;
+	}
+
+	private static Method findMethod(Class<?> type, String methodName) {
+		try {
+			return type.getMethod(methodName);
+		} catch (NoSuchMethodException e) {
+			return null;
+		}
+	}
+
+	private static Object resolveResidentTown(Object resident) throws IllegalAccessException, InvocationTargetException {
+		if (resident == null) {
+			return null;
+		}
+
+		if (residentGetTownOrNullMethod != null) {
+			return residentGetTownOrNullMethod.invoke(resident);
+		}
+
+		if (residentGetTownMethod != null) {
+			return residentGetTownMethod.invoke(resident);
+		}
+
+		return null;
+	}
+
+	private static Object resolveTownBlockTown(Object townBlock) throws IllegalAccessException, InvocationTargetException {
+		if (townBlock == null) {
+			return null;
+		}
+
+		if (townBlockGetTownOrNullMethod != null) {
+			return townBlockGetTownOrNullMethod.invoke(townBlock);
+		}
+
+		if (townBlockGetTownMethod != null) {
+			return townBlockGetTownMethod.invoke(townBlock);
+		}
+
+		return null;
+	}
+
+	private static void warnRuntime(String context, Throwable t) {
+		if (runtimeWarningLogged) {
+			return;
+		}
+		runtimeWarningLogged = true;
+
+		String suffix = (t != null) ? (": " + shortError(t)) : "";
+		Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+				+ "Towny compatibility runtime check failed while " + context + suffix + ".");
+		MobHunting.getInstance().getMessages().debug("Towny runtime compatibility failure while %s%s", context,
+				(t != null) ? (": " + shortError(t)) : "");
+	}
+
+	private static String shortError(Throwable t) {
+		String message = t.getMessage();
+		if (message == null || message.trim().isEmpty()) {
+			return t.getClass().getSimpleName();
+		}
+		return t.getClass().getSimpleName() + ": " + message;
 	}
 
 }

--- a/src/one/lindegaard/MobHunting/rewards/RewardManager.java
+++ b/src/one/lindegaard/MobHunting/rewards/RewardManager.java
@@ -542,6 +542,16 @@ public class RewardManager {
 			return 0;
 
 		} else {
+			// 1.21+ compatibility aliases for entities not exposed as dedicated sections yet.
+			if (isEntityType(mob, "ARMADILLO"))
+				return getPrice(mob, plugin.getConfigManager().turtleMoney);
+			else if (isEntityType(mob, "BOGGED"))
+				return getPrice(mob, plugin.getConfigManager().strayMoney);
+			else if (isEntityType(mob, "BREEZE"))
+				return getPrice(mob, plugin.getConfigManager().vexMoney);
+			else if (isEntityType(mob, "CREAKING"))
+				return getPrice(mob, plugin.getConfigManager().wardenMoney);
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return getPrice(mob, plugin.getConfigManager().allayMoney);
@@ -856,6 +866,10 @@ public class RewardManager {
 		}
 	}
 
+	private boolean isEntityType(Entity mob, String entityType) {
+		return mob != null && mob.getType() != null && mob.getType().name().equals(entityType);
+	}
+
 	/**
 	 * Get the command to be run when the player kills a Mob.
 	 * 
@@ -930,6 +944,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfCommands;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleCommands;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayCommands;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexCommands;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenCommands;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayCommands;
@@ -1258,6 +1281,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfMessage;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleMessage;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayMessage;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexMessage;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenMessage;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayMessage;
@@ -1577,6 +1609,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfCmdRunChance;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleMoneyChance;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayMoneyChance;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexMoneyChance;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenMoneyChance;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayMoneyChance;
@@ -1901,6 +1942,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfMcMMOSkillRewardChance;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleMcMMOSkillRewardChance;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayMcMMOSkillRewardChance;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexMcMMOSkillRewardChance;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenMcMMOSkillRewardChance;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayMcMMOSkillRewardChance;
@@ -2249,6 +2299,15 @@ public class RewardManager {
 			return getMcMMOXP(mob, plugin.getConfigManager().wolfMcMMOSkillRewardAmount);
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return getMcMMOXP(mob, plugin.getConfigManager().turtleMcMMOSkillRewardAmount);
+			else if (isEntityType(mob, "BOGGED"))
+				return getMcMMOXP(mob, plugin.getConfigManager().strayMcMMOSkillRewardAmount);
+			else if (isEntityType(mob, "BREEZE"))
+				return getMcMMOXP(mob, plugin.getConfigManager().vexMcMMOSkillRewardAmount);
+			else if (isEntityType(mob, "CREAKING"))
+				return getMcMMOXP(mob, plugin.getConfigManager().wardenMcMMOSkillRewardAmount);
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return getMcMMOXP(mob, plugin.getConfigManager().allayMcMMOSkillRewardAmount);
@@ -2568,6 +2627,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfEnabled;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleEnabled;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayEnabled;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexEnabled;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenEnabled;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayEnabled;
@@ -2898,6 +2966,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfHeadDropHead;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleHeadDropHead;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayHeadDropHead;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexHeadDropHead;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenHeadDropHead;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayHeadDropHead;
@@ -3230,6 +3307,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfHeadDropChance;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleHeadDropChance;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayHeadDropChance;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexHeadDropChance;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenHeadDropChance;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayHeadDropChance;
@@ -3561,6 +3647,15 @@ public class RewardManager {
 			return plugin.getConfigManager().wolfHeadMessage;
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return plugin.getConfigManager().turtleHeadMessage;
+			else if (isEntityType(mob, "BOGGED"))
+				return plugin.getConfigManager().strayHeadMessage;
+			else if (isEntityType(mob, "BREEZE"))
+				return plugin.getConfigManager().vexHeadMessage;
+			else if (isEntityType(mob, "CREAKING"))
+				return plugin.getConfigManager().wardenHeadMessage;
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return plugin.getConfigManager().allayHeadMessage;
@@ -3893,6 +3988,15 @@ public class RewardManager {
 			return getPrice(mob, plugin.getConfigManager().wolfHeadPrize);
 
 		} else {
+			if (isEntityType(mob, "ARMADILLO"))
+				return getPrice(mob, plugin.getConfigManager().turtleHeadPrize);
+			else if (isEntityType(mob, "BOGGED"))
+				return getPrice(mob, plugin.getConfigManager().strayHeadPrize);
+			else if (isEntityType(mob, "BREEZE"))
+				return getPrice(mob, plugin.getConfigManager().vexHeadPrize);
+			else if (isEntityType(mob, "CREAKING"))
+				return getPrice(mob, plugin.getConfigManager().wardenHeadPrize);
+
 			if (Servers.isMC119OrNewer())
 				if (mob instanceof Allay)
 					return getPrice(mob, plugin.getConfigManager().allayHeadPrize);

--- a/src/one/lindegaard/MobHunting/storage/DataStoreManager.java
+++ b/src/one/lindegaard/MobHunting/storage/DataStoreManager.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
@@ -168,23 +169,25 @@ public class DataStoreManager {
 		mExit = true;
 		flush();
 		mTaskThread.setWriteOnlyMode(true);
-		int n = 0;
+		mStoreThread.interrupt();
 		try {
-			while (mTaskThread.getState() != Thread.State.WAITING && mTaskThread.getState() != Thread.State.TERMINATED
-					&& n < 40) {
-				Thread.sleep(500);
-				n++;
+			boolean drained = mTaskThread.waitForEmptyQueue(TimeUnit.SECONDS.toMillis(15));
+			if (!drained) {
+				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+						+ "MobHunting shutdown timeout while waiting for async queue. Forcing thread stop.");
 			}
-			if (mTaskThread.getState() == Thread.State.RUNNABLE) {
-				mTaskThread.interrupt();
+			mTaskThread.interrupt();
+			mTaskThread.join(TimeUnit.SECONDS.toMillis(3));
+			if (mTaskThread.isAlive()) {
+				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+						+ "MobHunting async task thread did not terminate cleanly. Continuing server shutdown.");
 			}
-			if (mTaskThread.getState() != Thread.State.WAITING) {
-				mTaskThread.waitForEmptyQueue();
+			mStoreThread.join(TimeUnit.SECONDS.toMillis(3));
+			} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			Bukkit.getConsoleSender().sendMessage(
+					MobHunting.PREFIX_WARNING + "MobHunting shutdown was interrupted while waiting for async threads.");
 			}
-
-		} catch (InterruptedException e) {
-			e.printStackTrace();
-		}
 	}
 
 	/**
@@ -193,9 +196,13 @@ public class DataStoreManager {
 	public void waitForUpdates() {
 		flush();
 		try {
-			mTaskThread.waitForEmptyQueue();
+			boolean drained = mTaskThread.waitForEmptyQueue(TimeUnit.SECONDS.toMillis(30));
+			if (!drained) {
+				Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+						+ "Timeout while waiting for MobHunting datastore updates to finish.");
+			}
 		} catch (InterruptedException e) {
-			e.printStackTrace();
+			Thread.currentThread().interrupt();
 		}
 	}
 
@@ -210,6 +217,7 @@ public class DataStoreManager {
 
 		public StoreThread(int interval) {
 			super("MH StoreThread");
+			setDaemon(true);
 			start();
 			mSaveInterval = interval;
 		}
@@ -280,21 +288,33 @@ public class DataStoreManager {
 			super("MH TaskThread");
 
 			mQueue = new LinkedBlockingQueue<Task>();
+			setDaemon(true);
 
 			start();
 		}
 
 		public void waitForEmptyQueue() throws InterruptedException {
-			if (mQueue.isEmpty())
-				return;
+			waitForEmptyQueue(TimeUnit.MINUTES.toMillis(5));
+		}
 
+		public boolean waitForEmptyQueue(long timeoutMillis) throws InterruptedException {
+			if (mQueue.isEmpty())
+				return true;
+
+			long deadline = System.currentTimeMillis() + Math.max(timeoutMillis, 1L);
 			synchronized (mSignal) {
 				plugin.getMessages().debug(
 						"waitForEmptyQueue: Waiting for %s+%s tasks to finish before closing connections.",
 						mQueue.size(), mWaiting.size());
-				while (!mQueue.isEmpty())
-					mSignal.wait();
+				while (!mQueue.isEmpty()) {
+					long remaining = deadline - System.currentTimeMillis();
+					if (remaining <= 0) {
+						return false;
+					}
+					mSignal.wait(Math.min(remaining, 1000L));
+				}
 			}
+			return true;
 		}
 
 		public void setWriteOnlyMode(boolean writes) {

--- a/src/one/lindegaard/MobHunting/storage/DatabaseDataStore.java
+++ b/src/one/lindegaard/MobHunting/storage/DatabaseDataStore.java
@@ -1267,7 +1267,17 @@ public abstract class DatabaseDataStore implements IDataStore {
 			try {
 				openPreparedStatements(mConnection, PreparedConnectionType.SAVE_ACHIEVEMENTS);
 				for (AchievementStore achievement : achievements) {
-					int playerId = Core.getDataStoreManager().getPlayerId(achievement.player);
+					int playerId;
+					try {
+						playerId = Core.getDataStoreManager().getPlayerId(achievement.player);
+					} catch (UserNotFoundException e) {
+						String playerName = achievement.player != null ? achievement.player.getName() : "null";
+						String playerUuid = achievement.player != null ? String.valueOf(achievement.player.getUniqueId())
+								: "null";
+						Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+								+ "Skipping Achievement save for missing player " + playerName + " (" + playerUuid + ")");
+						continue;
+					}
 					mSaveAchievement.setInt(1, playerId);
 					mSaveAchievement.setString(2, achievement.id);
 					mSaveAchievement.setDate(3, new Date(System.currentTimeMillis()));
@@ -1278,7 +1288,7 @@ public abstract class DatabaseDataStore implements IDataStore {
 				mSaveAchievement.close();
 				mConnection.commit();
 				mConnection.close();
-			} catch (SQLException | UserNotFoundException e) {
+			} catch (SQLException e) {
 				rollback(mConnection);
 				mConnection.close();
 				throw new DataStoreException(e);

--- a/src/one/lindegaard/MobHunting/storage/MySQLDataStore.java
+++ b/src/one/lindegaard/MobHunting/storage/MySQLDataStore.java
@@ -274,7 +274,16 @@ public class MySQLDataStore extends DatabaseDataStore {
 				String column2 = "total_cash";
 				int amount = stat.getAmount();
 				double cash = Tools.round(stat.getCash());
-				int player_id = Core.getDataStoreManager().getPlayerId(stat.getPlayer());
+				int player_id;
+				try {
+					player_id = Core.getDataStoreManager().getPlayerId(stat.getPlayer());
+				} catch (UserNotFoundException e) {
+					String playerName = stat.getPlayer() != null ? stat.getPlayer().getName() : "null";
+					String playerUuid = stat.getPlayer() != null ? String.valueOf(stat.getPlayer().getUniqueId()) : "null";
+					Bukkit.getConsoleSender().sendMessage(MobHunting.PREFIX_WARNING
+							+ "Skipping PlayerStats save for missing player " + playerName + " (" + playerUuid + ")");
+					continue;
+				}
 				statement.executeUpdate(String.format(Locale.US,
 						"INSERT INTO mh_Daily(ID, MOB_ID, PLAYER_ID, %1$s, %5$s)"
 								+ " VALUES(DATE_FORMAT(NOW(), '%%Y%%j'),%2$d,%3$d,%4$d,%6$f)"
@@ -288,9 +297,6 @@ public class MySQLDataStore extends DatabaseDataStore {
 		} catch (SQLException e) {
 			rollback(mConnection);
 			throw new DataStoreException(e);
-		} catch (UserNotFoundException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
 		}
 	}
 


### PR DESCRIPTION
This JL build improves async datastore shutdown behavior to reduce stop/restart hangs, adds safer Citizens integration handling for newer server APIs, and includes Paper compatibility guards for modern 1.21.x environments. Important: there is no automatic balance/database migration between old and new custom token/economy flows. For the cleanest rollout, start with a fresh database snapshot/environment. Tested scope: Paper 1.21.11 only.